### PR TITLE
v1.88:

### DIFF
--- a/Include/NRI.h
+++ b/Include/NRI.h
@@ -16,8 +16,8 @@ license agreement from NVIDIA CORPORATION is strictly prohibited.
 #include <cstddef>
 
 #define NRI_VERSION_MAJOR 1
-#define NRI_VERSION_MINOR 87
-#define NRI_VERSION_DATE "5 October 2022"
+#define NRI_VERSION_MINOR 88
+#define NRI_VERSION_DATE "15 November 2022"
 #define NRI_INTERFACE( name ) #name, sizeof(name)
 
 #if _WIN32

--- a/Include/NRIDescs.h
+++ b/Include/NRIDescs.h
@@ -1117,6 +1117,8 @@ namespace nri
         const ClearValueDesc* depthStencilClearValue;
         uint32_t colorAttachmentNum;
         uint32_t physicalDeviceMask;
+        uint16_t size[2];
+        uint16_t layerNum;
     };
 
     struct QueryPoolDesc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NVIDIA Render Interface v1.87 (NRI)
+# NVIDIA Render Interface v1.88 (NRI)
 
 *NRI* is a low-level abstract render interface which currently supports three backends: D3D11, D3D12 and Vulkan. *NRI* has been designed to support all (at least major) low level features of D3D12 and Vulkan APIs, but at the same time to simplify usage and reduce the amount of code needed (especially compared with Vulkan).
 

--- a/Source/D3D12/FrameBufferD3D12.cpp
+++ b/Source/D3D12/FrameBufferD3D12.cpp
@@ -59,7 +59,7 @@ void FrameBufferD3D12::Bind(ID3D12GraphicsCommandList* graphicsCommandList, Rend
 {
     graphicsCommandList->OMSetRenderTargets(
         (UINT)m_RenderTargets.size(),
-        &m_RenderTargets[0],
+        m_RenderTargets.data(),
         FALSE,
         m_DepthStencilTarget.ptr != 0 ? &m_DepthStencilTarget : nullptr
     );

--- a/Source/VK/CommandBufferVK.cpp
+++ b/Source/VK/CommandBufferVK.cpp
@@ -201,12 +201,13 @@ inline void CommandBufferVK::ClearAttachments(const ClearDesc* clearDescs, uint3
         rectNum = clearDescNum;
 
         const VkRect2D& rect = m_CurrentFrameBuffer->GetRenderArea();
+        const uint32_t layerNum = m_CurrentFrameBuffer->GetLayerNum();
 
         for (uint32_t i = 0; i < clearDescNum; i++)
         {
             VkClearRect& clearRect = clearRects[i];
             clearRect.baseArrayLayer = 0;
-            clearRect.layerCount = 1;
+            clearRect.layerCount = layerNum;
             clearRect.rect = rect;
         }
     }

--- a/Source/VK/DeviceVK.cpp
+++ b/Source/VK/DeviceVK.cpp
@@ -309,9 +309,7 @@ void DeviceVK::FindDXGIAdapter()
 bool DeviceVK::GetMemoryType(MemoryLocation memoryLocation, uint32_t memoryTypeMask, MemoryTypeInfo& memoryTypeInfo) const
 {
     const VkMemoryPropertyFlags host = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-
-    VkMemoryPropertyFlags hostUnwantedFlags =
-        (memoryLocation == nri::MemoryLocation::HOST_READBACK) ? VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT : 0;
+    const VkMemoryPropertyFlags hostUnwantedFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 
     const VkMemoryPropertyFlags device = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     const VkMemoryPropertyFlags deviceUnwantedFlags = 0;
@@ -328,7 +326,7 @@ bool DeviceVK::GetMemoryType(MemoryLocation memoryLocation, uint32_t memoryTypeM
     {
         const bool isMemoryTypeSupported = memoryTypeMask & (1 << i);
         const bool isPropSupported = (m_MemoryProps.memoryTypes[i].propertyFlags & flags) == flags;
-        const bool hasUnwantedProperties = (m_MemoryProps.memoryTypes[i].propertyFlags & unwantedFlags) == 0;
+        const bool hasUnwantedProperties = (m_MemoryProps.memoryTypes[i].propertyFlags & unwantedFlags) != 0;
 
         if (isMemoryTypeSupported && isPropSupported && !hasUnwantedProperties)
         {

--- a/Source/VK/FrameBufferVK.h
+++ b/Source/VK/FrameBufferVK.h
@@ -23,6 +23,7 @@ namespace nri
         Result Create(const FrameBufferDesc& frameBufferDesc);
         VkFramebuffer GetHandle(uint32_t physicalDeviceIndex) const;
         const VkRect2D& GetRenderArea() const;
+        uint32_t GetLayerNum() const;
         VkRenderPass GetRenderPass(RenderPassBeginFlag renderPassBeginFlag) const;
         uint32_t GetAttachmentNum() const;
         void GetClearValues(VkClearValue* values) const;
@@ -41,6 +42,7 @@ namespace nri
         VkRenderPass m_RenderPass = VK_NULL_HANDLE;
         std::array<ClearValueDesc, ATTACHMENT_MAX_NUM> m_ClearValues = {};
         VkRect2D m_RenderArea = {};
+        uint32_t m_LayerNum = 0;
         uint32_t m_AttachmentNum = 0;
         DeviceVK& m_Device;
     };
@@ -63,6 +65,11 @@ namespace nri
     inline VkRenderPass FrameBufferVK::GetRenderPass(RenderPassBeginFlag renderPassBeginFlag) const
     {
         return (renderPassBeginFlag == RenderPassBeginFlag::SKIP_FRAME_BUFFER_CLEAR) ? m_RenderPass : m_RenderPassWithClear;
+    }
+
+    inline uint32_t FrameBufferVK::GetLayerNum() const
+    {
+        return m_LayerNum;
     }
 
     inline const VkRect2D& FrameBufferVK::GetRenderArea() const

--- a/Source/Validation/DeviceSemaphoreVal.h
+++ b/Source/Validation/DeviceSemaphoreVal.h
@@ -18,8 +18,7 @@ namespace nri
 
         void Create(bool signaled);
 
-        inline bool DeviceSemaphoreVal::IsUnsignaled() const
-        { return (m_Value & 0x1) == 0; }
+        inline bool IsUnsignaled() const;
 
         //======================================================================================================================
         // NRI
@@ -32,4 +31,9 @@ namespace nri
     private:
         uint64_t m_Value = 0;
     };
+
+    inline bool DeviceSemaphoreVal::IsUnsignaled() const
+    {
+        return (m_Value & 0x1) == 0;
+    }
 }


### PR DESCRIPTION
- API: added "size" and "layerNum" to FrameBufferDesc to unlock render passes without attachments
- VK: excluded HVV memory in "GetMemoryType"
- VK: fixed "GetMemoryType"
- D3D12: fixed potential crash
- fixed compilation error for Clang13