### PR TITLE
v1.132:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,3 +296,18 @@ set_property (TARGET ${PROJECT_NAME} PROPERTY FOLDER ${PROJECT_NAME})
 
 set_target_properties (${PROJECT_NAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 message ("NRI output path: '${CMAKE_RUNTIME_OUTPUT_DIRECTORY}'")
+
+if (WIN32)
+    if (NRI_ENABLE_D3D11_SUPPORT OR NRI_ENABLE_D3D12_SUPPORT)
+        # Function - copy a library to the output folder of a project
+        function (copy_library PROJECT LIBRARY_NAME)
+            add_custom_command (TARGET ${PROJECT} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LIBRARY_NAME} $<TARGET_FILE_DIR:${PROJECT}>
+                COMMAND_EXPAND_LISTS)
+        endfunction ()
+
+        # Copy AMD AGS into the output folder
+        find_file (AMD_AGS_DLL NAMES amd_ags_x64.dll PATHS "External/amdags/ags_lib/lib")
+        copy_library (${PROJECT_NAME} ${AMD_AGS_DLL})
+    endif ()
+endif ()

--- a/Include/Extensions/NRIHelper.h
+++ b/Include/Extensions/NRIHelper.h
@@ -58,39 +58,33 @@ NRI_STRUCT(HelperInterface)
     NRI_NAME(Result) (NRI_CALL *WaitForIdle)(NRI_NAME_REF(CommandQueue) commandQueue);
 };
 
+// Information about video memory
 NRI_API bool NRI_CALL nriQueryVideoMemoryInfo(const NRI_NAME_REF(Device) device, NRI_NAME(MemoryLocation) memoryLocation, NRI_NAME_REF(VideoMemoryInfo) videoMemoryInfo);
 
+// Format conversion
 NRI_API NRI_NAME(Format) NRI_CALL nriConvertDXGIFormatToNRI(uint32_t dxgiFormat);
 NRI_API NRI_NAME(Format) NRI_CALL nriConvertVKFormatToNRI(uint32_t vkFormat);
 NRI_API uint32_t NRI_CALL nriConvertNRIFormatToDXGI(NRI_NAME(Format) format);
 NRI_API uint32_t NRI_CALL nriConvertNRIFormatToVK(NRI_NAME(Format) format);
 
+// Strings
 NRI_API const char* NRI_CALL nriGetGraphicsAPIString(NRI_NAME(GraphicsAPI) graphicsAPI);
 NRI_API const char* NRI_CALL nriGetFormatString(NRI_NAME(Format) format);
 
+// A friendly way to get a supported depth format
 static inline NRI_NAME(Format) NRI_FUNC_NAME(GetSupportedDepthFormat)(const NRI_NAME_REF(CoreInterface) coreInterface, const NRI_NAME_REF(Device) device, uint32_t minBits, bool stencil)
 {
-    if (stencil)
-    {
-        if (minBits <= 24)
-        {
-            if (NRI_REF_ACCESS(coreInterface)->GetFormatSupport(device, NRI_ENUM_MEMBER(Format, D24_UNORM_S8_UINT)) & NRI_ENUM_MEMBER(FormatSupportBits, DEPTH_STENCIL_ATTACHMENT))
-                return NRI_ENUM_MEMBER(Format, D24_UNORM_S8_UINT);
-        }
+    if (minBits <= 16 && !stencil) {
+        if (NRI_REF_ACCESS(coreInterface)->GetFormatSupport(device, NRI_ENUM_MEMBER(Format, D16_UNORM)) & NRI_ENUM_MEMBER(FormatSupportBits, DEPTH_STENCIL_ATTACHMENT))
+            return NRI_ENUM_MEMBER(Format, D16_UNORM);
     }
-    else
-    {
-        if (minBits <= 16)
-        {
-            if (NRI_REF_ACCESS(coreInterface)->GetFormatSupport(device, NRI_ENUM_MEMBER(Format, D16_UNORM)) & NRI_ENUM_MEMBER(FormatSupportBits, DEPTH_STENCIL_ATTACHMENT))
-                return NRI_ENUM_MEMBER(Format, D16_UNORM);
-        }
-        else if (minBits <= 24)
-        {
-            if (NRI_REF_ACCESS(coreInterface)->GetFormatSupport(device, NRI_ENUM_MEMBER(Format, D24_UNORM_S8_UINT)) & NRI_ENUM_MEMBER(FormatSupportBits, DEPTH_STENCIL_ATTACHMENT))
-                return NRI_ENUM_MEMBER(Format, D24_UNORM_S8_UINT);
-        }
+        
+    if (minBits <= 24) {
+        if (NRI_REF_ACCESS(coreInterface)->GetFormatSupport(device, NRI_ENUM_MEMBER(Format, D24_UNORM_S8_UINT)) & NRI_ENUM_MEMBER(FormatSupportBits, DEPTH_STENCIL_ATTACHMENT))
+            return NRI_ENUM_MEMBER(Format, D24_UNORM_S8_UINT);
+    }
 
+    if (minBits <= 32 && !stencil) {
         if (NRI_REF_ACCESS(coreInterface)->GetFormatSupport(device, NRI_ENUM_MEMBER(Format, D32_SFLOAT)) & NRI_ENUM_MEMBER(FormatSupportBits, DEPTH_STENCIL_ATTACHMENT))
             return NRI_ENUM_MEMBER(Format, D32_SFLOAT);
     }
@@ -98,6 +92,7 @@ static inline NRI_NAME(Format) NRI_FUNC_NAME(GetSupportedDepthFormat)(const NRI_
     if (NRI_REF_ACCESS(coreInterface)->GetFormatSupport(device, NRI_ENUM_MEMBER(Format, D32_SFLOAT_S8_UINT_X24)) & NRI_ENUM_MEMBER(FormatSupportBits, DEPTH_STENCIL_ATTACHMENT))
         return NRI_ENUM_MEMBER(Format, D32_SFLOAT_S8_UINT_X24);
 
+    // Should be unreachable
     return NRI_ENUM_MEMBER(Format, UNKNOWN);
 }
 

--- a/Include/NRI.h
+++ b/Include/NRI.h
@@ -25,8 +25,8 @@ Non-goals:
 #include <stddef.h>
 
 #define NRI_VERSION_MAJOR 1
-#define NRI_VERSION_MINOR 131
-#define NRI_VERSION_DATE "7 May 2024"
+#define NRI_VERSION_MINOR 132
+#define NRI_VERSION_DATE "9 May 2024"
 
 #ifdef _WIN32
     #define NRI_CALL __fastcall

--- a/Resources/Version.h
+++ b/Resources/Version.h
@@ -4,7 +4,7 @@
 #define STR(x) STR_HELPER(x)
 
 #define VERSION_MAJOR                   1
-#define VERSION_MINOR                   131
+#define VERSION_MINOR                   132
 #define VERSION_BUILD                   0
 #define VERSION_REVISION                0
 

--- a/Source/VK/ConversionVK.h
+++ b/Source/VK/ConversionVK.h
@@ -158,6 +158,22 @@ inline VkFormat GetVkFormat(Format format, bool demoteSrgb = false) {
     return (VkFormat)NRIFormatToVKFormat(format);
 }
 
+inline bool HasStencil(Format format) {
+    switch (format)
+    {
+    case nri::Format::D24_UNORM_S8_UINT:
+        return true;
+    case nri::Format::D32_SFLOAT_S8_UINT_X24:
+        return true;
+    case nri::Format::X24_G8_UINT:
+        return true;
+    case nri::Format::X32_G8_UINT_X24:
+        return true;
+    default:
+        return false;
+    }
+}
+
 constexpr std::array<VkPrimitiveTopology, (uint32_t)Topology::MAX_NUM> TOPOLOGIES = {
     VK_PRIMITIVE_TOPOLOGY_POINT_LIST,                    // POINT_LIST
     VK_PRIMITIVE_TOPOLOGY_LINE_LIST,                     // LINE_LIST

--- a/Source/VK/PipelineVK.cpp
+++ b/Source/VK/PipelineVK.cpp
@@ -196,7 +196,7 @@ Result PipelineVK::Create(const GraphicsPipelineDesc& graphicsPipelineDesc) {
     pipelineRenderingCreateInfo.colorAttachmentCount = om.colorNum;
     pipelineRenderingCreateInfo.pColorAttachmentFormats = colorFormats;
     pipelineRenderingCreateInfo.depthAttachmentFormat = GetVkFormat(om.depthStencilFormat);
-    pipelineRenderingCreateInfo.stencilAttachmentFormat = GetVkFormat(om.depthStencilFormat);
+    pipelineRenderingCreateInfo.stencilAttachmentFormat = HasStencil(om.depthStencilFormat) ? GetVkFormat(om.depthStencilFormat) : VK_FORMAT_UNDEFINED;
 
     // Dynamic state
     uint32_t dynamicStateNum = 0;


### PR DESCRIPTION
HIGHLIGHTS:
- bug fixes and improvements

DETAILS:
- CMAKE: AMD AGS is copied to the same location as NRI.dll (if there is a D3D backend)
- VK: fixed stencil misuse if a depth-stencil format is actually depth-only
- Helper: a bit massaged header (no functional changes)